### PR TITLE
chore: add dev container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,4 @@
+FROM nixos/nix
+
+RUN mkdir -p ~/.config/nix \
+    && echo "experimental-features = nix-command flakes" > ~/.config/nix/nix.conf

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,8 +1,10 @@
-FROM rust:1-trixie
+FROM mcr.microsoft.com/devcontainers/rust:1
 
 # Install extra packages
-RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -y install --no-install-recommends liquidsoap ffmpeg
-
-# Install SQLx
-RUN cargo install sqlx-cli --no-default-features --features sqlite
+RUN apt-get update \
+  && export DEBIAN_FRONTEND=noninteractive \
+  && apt-get -y install --no-install-recommends \
+     mold \
+     liquidsoap \
+     ffmpeg \
+  && rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,8 @@
-FROM nixos/nix
+FROM rust:1-trixie
 
-RUN mkdir -p ~/.config/nix \
-    && echo "experimental-features = nix-command flakes" > ~/.config/nix/nix.conf
+# Install extra packages
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends liquidsoap
+
+# Install SQLx
+RUN cargo install sqlx-cli --no-default-features --features sqlite

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,7 +2,7 @@ FROM rust:1-trixie
 
 # Install extra packages
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -y install --no-install-recommends liquidsoap
+    && apt-get -y install --no-install-recommends liquidsoap ffmpeg
 
 # Install SQLx
 RUN cargo install sqlx-cli --no-default-features --features sqlite

--- a/.devcontainer/compose.yaml
+++ b/.devcontainer/compose.yaml
@@ -1,0 +1,21 @@
+services:
+  playout:
+    build:
+      dockerfile: Dockerfile
+      context: .
+    ports:
+      - 3000:3000
+    depends_on:
+      - mediamtx
+    volumes:
+      - ..:/workspace
+    command: sleep infinity
+  mediamtx:
+    image: bluenviron/mediamtx:1
+    ports:
+      - 8554:8554
+      - 1935:1935
+      - 8888:8888
+      - 8889:8889
+      - 8890:8890/udp
+      - 8189:8189/udp

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,9 +1,23 @@
 {
-  "name": "Nix",
-  "build": {
-    "dockerfile": "Dockerfile",
-    "context": ".",
-  },
-  "postStartCommand": "nix develop",
-  "forwardPorts": [3000],
+    "name": "Debian",
+    "build": {
+        "dockerfile": "./Dockerfile",
+        "context": "."
+    },
+    "features": {
+        "ghcr.io/devcontainers/features/common-utils:2": {
+            "installZsh": "true",
+            "username": "dev",
+            "userUid": "1000",
+            "userGid": "1000",
+            "upgradePackages": "true"
+        },
+        "ghcr.io/devcontainers/features/rust:1": "latest",
+        "ghcr.io/devcontainers/features/git:1": {
+            "version": "latest",
+            "ppa": "false"
+        }
+    },
+    "forwardPorts": [3000],
+    "remoteUser": "dev"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,23 +1,12 @@
 {
     "name": "Debian",
     "build": {
-        "dockerfile": "./Dockerfile",
-        "context": "."
+        "dockerfile": "./Dockerfile"
     },
-    "features": {
-        "ghcr.io/devcontainers/features/common-utils:2": {
-            "installZsh": "true",
-            "username": "dev",
-            "userUid": "1000",
-            "userGid": "1000",
-            "upgradePackages": "true"
-        },
-        "ghcr.io/devcontainers/features/rust:1": "latest",
-        "ghcr.io/devcontainers/features/git:1": {
-            "version": "latest",
-            "ppa": "false"
-        }
-    },
+    "postCreateCommand": "RUSTFLAGS=\"-C link-arg=-fuse-ld=mold\" cargo install sqlx-cli --no-default-features --features sqlite",
     "forwardPorts": [3000],
-    "remoteUser": "dev"
+    "remoteUser": "vscode",
+    "mounts": [
+        "source=cargo-cache,target=/home/vscode/.cargo,type=volume"
+    ]
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,9 @@
+{
+  "name": "Nix",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": ".",
+  },
+  "postStartCommand": "nix develop",
+  "forwardPorts": [3000],
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,12 +1,12 @@
 {
-    "name": "Debian",
-    "build": {
-        "dockerfile": "./Dockerfile"
-    },
-    "postCreateCommand": "RUSTFLAGS=\"-C link-arg=-fuse-ld=mold\" cargo install sqlx-cli --no-default-features --features sqlite",
-    "forwardPorts": [3000],
-    "remoteUser": "vscode",
-    "mounts": [
-        "source=cargo-cache,target=/home/vscode/.cargo,type=volume"
-    ]
+  "name": "Debian",
+
+  "dockerComposeFile": ["compose.yaml"],
+  "service": "playout",
+  "workspaceFolder": "/workspace",
+
+  "postCreateCommand": "RUSTFLAGS=\"-C link-arg=-fuse-ld=mold\" cargo install sqlx-cli --no-default-features --features sqlite",
+  "forwardPorts": [3000],
+  "remoteUser": "vscode",
+  "mounts": ["source=cargo-cache,target=/home/vscode/.cargo,type=volume"]
 }

--- a/.gitattributes
+++ b/.gitattributes
@@ -97,9 +97,8 @@
 .gitignore     export-ignore
 .gitkeep       export-ignore
 
-# Auto detect text files and perform normalization
-*          text=auto
-
 *.rs       text diff=rust
 *.toml     text diff=toml
 Cargo.lock text
+
+*.nix text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,105 @@
+# Common settings that generally should always be used with your language specific settings
+
+# Auto detect text files and perform LF normalization
+*          text=auto
+
+#
+# The above will handle all files NOT found below
+#
+
+# Documents
+*.bibtex   text diff=bibtex
+*.doc      diff=astextplain
+*.DOC      diff=astextplain
+*.docx     diff=astextplain
+*.DOCX     diff=astextplain
+*.dot      diff=astextplain
+*.DOT      diff=astextplain
+*.pdf      diff=astextplain
+*.PDF      diff=astextplain
+*.rtf      diff=astextplain
+*.RTF      diff=astextplain
+*.md       text diff=markdown
+*.mdx      text diff=markdown
+*.tex      text diff=tex
+*.adoc     text
+*.textile  text
+*.mustache text
+*.csv      text eol=crlf
+*.tab      text
+*.tsv      text
+*.txt      text
+*.sql      text
+*.epub     diff=astextplain
+
+# Graphics
+*.png      binary
+*.jpg      binary
+*.jpeg     binary
+*.gif      binary
+*.tif      binary
+*.tiff     binary
+*.ico      binary
+# SVG treated as text by default.
+*.svg      text
+# If you want to treat it as binary,
+# use the following line instead.
+# *.svg    binary
+*.eps      binary
+
+# Scripts
+*.bash     text eol=lf
+*.fish     text eol=lf
+*.ksh      text eol=lf
+*.sh       text eol=lf
+*.zsh      text eol=lf
+# These are explicitly windows files and should use crlf
+*.bat      text eol=crlf
+*.cmd      text eol=crlf
+*.ps1      text eol=crlf
+
+# Serialisation
+*.json     text
+*.toml     text
+*.xml      text
+*.yaml     text
+*.yml      text
+
+# Archives
+*.7z       binary
+*.bz       binary
+*.bz2      binary
+*.bzip2    binary
+*.gz       binary
+*.lz       binary
+*.lzma     binary
+*.rar      binary
+*.tar      binary
+*.taz      binary
+*.tbz      binary
+*.tbz2     binary
+*.tgz      binary
+*.tlz      binary
+*.txz      binary
+*.xz       binary
+*.Z        binary
+*.zip      binary
+*.zst      binary
+
+# Text files where line endings should be preserved
+*.patch    -text
+
+#
+# Exclude files from exporting
+#
+
+.gitattributes export-ignore
+.gitignore     export-ignore
+.gitkeep       export-ignore
+
+# Auto detect text files and perform normalization
+*          text=auto
+
+*.rs       text diff=rust
+*.toml     text diff=toml
+Cargo.lock text

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Loading the `.env` file is up to you.
 
 ### Database
 
-Create the database with `sqlx database create`.
+Create the database with `sqlx database create` and run migrations with `sqlx migrate run`.
 
 ### Running
 

--- a/flake.nix
+++ b/flake.nix
@@ -63,9 +63,16 @@
             sqlite
           ] ++ deps;
 
+          shellHook = ''
+            if [ -f .env ]; then
+              set -a
+              source .env
+              set +a
+            fi
+          '';
+
           LD_LIBRARY_PATH = "${pkgs.lib.makeLibraryPath deps}";
         };
       }
     );
 }
-


### PR DESCRIPTION
This pull request adds a devcontainer to the project for people not using the Nix package manager. ~~The container runs a Nix Docker image, allowing the developer to run `nix develop` to bootstrap the environment, rather than duplicating any setup.~~ The container runs a Debian image which installs `mold`, `liquidsoap`, `ffmpeg` and `sqlx-cli`. As much as I would love to wrap the Nix flake, the IDE integration was awful.

Real reason for PR: my desktop is still on Windows (sorry..)