### PR TITLE
feat!: add skip button

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ API_TOKEN=changeme
 
 SRT_HOST=mediamtx
 SRT_PORT=8890
+SRT_USERNAME=username
+SRT_PASSWORD=password
 SRT_STREAM_ID=test-venue
 HLS_BASE_URL=http://mediamtx:8888
 ```

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ EVENING_JINGLES_FILE=/data/evening-jingles.txt
 
 PLAYLIST_FILE=./playlist-gen.txt
 
+UNIX_SOCKET_PATH=test/campus-playout.sock
+
 API_TOKEN=changeme
 
 SRT_HOST=mediamtx

--- a/justfile
+++ b/justfile
@@ -1,0 +1,19 @@
+default:
+    just --list
+
+[group("control server")]
+serve:
+    cargo run
+
+[group("database")]
+database-setup:
+    cargo sqlx database create
+    just database-migrate
+
+[group("database")]
+database-migrate:
+    cargo sqlx migrate run
+
+[group("streamer")]
+streamer:
+    liquidsoap scripts/playout.liq

--- a/scripts/playout.liq
+++ b/scripts/playout.liq
@@ -3,7 +3,6 @@
 settings.frame.audio.channels := 2
 settings.frame.audio.samplerate := 48000
 
-settings.server.telnet := true
 settings.server.socket := true
 
 # bodge for docker :(
@@ -76,10 +75,18 @@ timed_jingles = switch([
 
 tracks = playlist(playlist_file, reload_mode="watch")
 
+def skip_track(_) =
+  tracks.skip()
+  "Done\n"
+end
+server.register(
+  namespace="playout",
+  "skip",
+  skip_track
+)
+
 playout = random(weights=[1, 1, 6], [jingles, timed_jingles, tracks])
-
 playout = crossfade(playout)
-
 playout = mksafe(playout)
 
 playout.on_metadata(synchronous=false, new_metadata)

--- a/scripts/playout.liq
+++ b/scripts/playout.liq
@@ -82,7 +82,7 @@ playout = crossfade(playout)
 
 playout = mksafe(playout)
 
-playout.on_metadata(synchronous=true, new_metadata)
+playout.on_metadata(synchronous=false, new_metadata)
 
 enc = %ffmpeg(
   format = "mpegts",

--- a/scripts/playout.liq
+++ b/scripts/playout.liq
@@ -4,6 +4,7 @@ settings.frame.audio.channels := 2
 settings.frame.audio.samplerate := 48000
 
 settings.server.telnet := true
+settings.server.socket := true
 
 # bodge for docker :(
 settings.init.allow_root := true
@@ -35,8 +36,11 @@ jingles_file = get_env("JINGLES_FILE")
 morning_jingles_file = get_env("MORNING_JINGLES_FILE")
 afternoon_jingles_file = get_env("AFTERNOON_JINGLES_FILE")
 evening_jingles_file = get_env("EVENING_JINGLES_FILE")
+unix_socket_path = get_env("UNIX_SOCKET_PATH")
 srt_username = get_env("SRT_USERNAME")
 srt_password = get_env("SRT_PASSWORD")
+
+settings.server.socket.path := unix_socket_path
 
 def get_trackid(meta) =
   trackid = list.assoc(default="", "trackid", meta)

--- a/scripts/playout.liq
+++ b/scripts/playout.liq
@@ -78,7 +78,7 @@ playout = crossfade(playout)
 
 playout = mksafe(playout)
 
-playout.on_metadata(new_metadata)
+playout.on_metadata(synchronous=true, new_metadata)
 
 enc = %ffmpeg(
   format = "mpegts",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,8 @@
-pub mod auth;
 pub mod apis;
+pub mod auth;
 pub mod database;
 pub mod error;
+pub mod liquidsoap;
 pub mod model;
 pub mod playlist;
 pub mod routes;

--- a/src/liquidsoap/backend/mod.rs
+++ b/src/liquidsoap/backend/mod.rs
@@ -12,6 +12,6 @@ pub trait LiquidsoapBackend {
 }
 
 #[cfg(unix)]
-pub fn unix<P: ?Sized + Into<PathBuf>>(path: P) -> unix::UnixLiquidsoapBackend {
+pub fn unix<P: Into<PathBuf>>(path: P) -> unix::UnixLiquidsoapBackend {
     unix::UnixLiquidsoapBackend::new(path)
 }

--- a/src/liquidsoap/backend/mod.rs
+++ b/src/liquidsoap/backend/mod.rs
@@ -1,0 +1,17 @@
+#[cfg(unix)]
+use std::path::PathBuf;
+
+#[cfg(unix)]
+pub mod unix;
+
+#[allow(async_fn_in_trait, reason = "we only use this trait internally")]
+pub trait LiquidsoapBackend {
+    type Error;
+
+    async fn skip_track(&self) -> Result<(), Self::Error>;
+}
+
+#[cfg(unix)]
+pub fn unix<P: ?Sized + Into<PathBuf>>(path: P) -> unix::UnixLiquidsoapBackend {
+    unix::UnixLiquidsoapBackend::new(path)
+}

--- a/src/liquidsoap/backend/unix.rs
+++ b/src/liquidsoap/backend/unix.rs
@@ -10,11 +10,11 @@ pub struct UnixLiquidsoapBackend {
     path: PathBuf,
 }
 
-impl<'a> UnixLiquidsoapBackend {
+impl UnixLiquidsoapBackend {
     const ACTION_SEND_COMMAND: &'static [u8] = b"\n";
     const COMMAND_SKIP_TRACK: &'static [u8] = b"srt.skip";
 
-    pub fn new<P: ?Sized + Into<PathBuf>>(path: P) -> Self {
+    pub fn new<P: Into<PathBuf>>(path: P) -> Self {
         Self { path: path.into() }
     }
 

--- a/src/liquidsoap/backend/unix.rs
+++ b/src/liquidsoap/backend/unix.rs
@@ -12,7 +12,7 @@ pub struct UnixLiquidsoapBackend {
 
 impl UnixLiquidsoapBackend {
     const ACTION_SEND_COMMAND: &'static [u8] = b"\n";
-    const COMMAND_SKIP_TRACK: &'static [u8] = b"srt.skip";
+    const COMMAND_SKIP_TRACK: &'static [u8] = b"playout.skip";
 
     pub fn new<P: Into<PathBuf>>(path: P) -> Self {
         Self { path: path.into() }

--- a/src/liquidsoap/backend/unix.rs
+++ b/src/liquidsoap/backend/unix.rs
@@ -1,0 +1,57 @@
+use std::path::PathBuf;
+
+use thiserror::Error;
+use tokio::{io::AsyncWriteExt, net::UnixStream};
+
+use crate::liquidsoap::backend::LiquidsoapBackend;
+
+#[derive(Debug, Clone)]
+pub struct UnixLiquidsoapBackend {
+    path: PathBuf,
+}
+
+impl<'a> UnixLiquidsoapBackend {
+    const ACTION_SEND_COMMAND: &'static [u8] = b"\n";
+    const COMMAND_SKIP_TRACK: &'static [u8] = b"srt.skip";
+
+    pub fn new<P: ?Sized + Into<PathBuf>>(path: P) -> Self {
+        Self { path: path.into() }
+    }
+
+    async fn create_connection(&self) -> Result<UnixStream, std::io::Error> {
+        UnixStream::connect(&self.path).await
+    }
+
+    async fn send_command(
+        &self,
+        connection: &mut UnixStream,
+        command: &[u8],
+    ) -> Result<(), std::io::Error> {
+        // make sure connection is writable
+        connection.writable().await?;
+
+        // send command
+        connection.write(command).await?;
+        connection.write(Self::ACTION_SEND_COMMAND).await?;
+
+        // flush connection
+        connection.flush().await
+    }
+}
+
+impl LiquidsoapBackend for UnixLiquidsoapBackend {
+    type Error = UnixLiquidsoapBackendError;
+
+    async fn skip_track(&self) -> Result<(), Self::Error> {
+        let mut connection = self.create_connection().await?;
+        self.send_command(&mut connection, Self::COMMAND_SKIP_TRACK)
+            .await?;
+        Ok(())
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum UnixLiquidsoapBackendError {
+    #[error("io error")]
+    Io(#[from] std::io::Error),
+}

--- a/src/liquidsoap/mod.rs
+++ b/src/liquidsoap/mod.rs
@@ -1,0 +1,3 @@
+mod backend;
+
+pub use backend::{LiquidsoapBackend, unix};

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,8 @@
 use std::path::PathBuf;
 
 use campus_playout_2026::{
-    apis::ApiClient, database::AppDatabase, playlist::PlaylistGenerator, routes, state::AppState,
-    templates::TemplateRenderer, tracks::TrackCache,
+    apis::ApiClient, database::AppDatabase, liquidsoap, playlist::PlaylistGenerator, routes,
+    state::AppState, templates::TemplateRenderer, tracks::TrackCache,
 };
 use tower_http::trace::TraceLayer;
 use tracing_subscriber::prelude::*;
@@ -25,10 +25,7 @@ async fn main() -> campus_playout_2026::Result<()> {
 
     let api_token = get_env!("API_TOKEN");
 
-    let database = AppDatabase::new(
-        &get_env!("DATABASE_URL"),
-    )
-    .await?;
+    let database = AppDatabase::new(&get_env!("DATABASE_URL")).await?;
 
     let client = ApiClient::new(
         get_env!("LAST_FM_API_KEY"),
@@ -47,10 +44,8 @@ async fn main() -> campus_playout_2026::Result<()> {
         format!("{stream_base}/{stream_id}/index.m3u8"),
     );
 
-    let playlist_generator = PlaylistGenerator::new(
-        client.clone(),
-        PathBuf::from(get_env!("PLAYLIST_FILE")),
-    );
+    let playlist_generator =
+        PlaylistGenerator::new(client.clone(), PathBuf::from(get_env!("PLAYLIST_FILE")));
 
     database.stop_all_tracks().await?;
 
@@ -65,7 +60,17 @@ async fn main() -> campus_playout_2026::Result<()> {
 
     playlist_generator.update_playlist(&playlist_id).await?;
 
-    let state = AppState::new(client, api_token, database, playlist_generator, template_renderer, track_cache);
+    let liquidsoap = liquidsoap::unix(get_env!("UNIX_SOCKET_PATH"));
+
+    let state = AppState::new(
+        client,
+        api_token,
+        database,
+        playlist_generator,
+        template_renderer,
+        track_cache,
+        liquidsoap,
+    );
 
     let app = routes::routes(state).layer(TraceLayer::new_for_http());
 

--- a/src/routes/admin.rs
+++ b/src/routes/admin.rs
@@ -5,9 +5,10 @@ use axum::{
     extract::State,
     routing::{get, post},
 };
+use miette::{Context, IntoDiagnostic};
 use serde::Deserialize;
 
-use crate::{apis::myradio::MyRadioPlaylist, state::AppState};
+use crate::{apis::myradio::MyRadioPlaylist, liquidsoap::LiquidsoapBackend, state::AppState};
 
 #[derive(Deserialize)]
 struct SetPlaylistBody {
@@ -35,9 +36,12 @@ async fn admin_page(State(state): State<AppState>) -> crate::Result<maud::Markup
     let recent_tracks = state.track_cache.resolve_recent_tracks(tracks).await?;
 
     let (current_playlist, available_playlists) = get_playlist_info(&state).await?;
-    Ok(state
-        .template_renderer
-        .admin_index(track, recent_tracks, current_playlist.as_deref(), available_playlists))
+    Ok(state.template_renderer.admin_index(
+        track,
+        recent_tracks,
+        current_playlist.as_deref(),
+        available_playlists,
+    ))
 }
 
 async fn set_playlist(
@@ -46,8 +50,14 @@ async fn set_playlist(
 ) -> crate::Result<maud::Markup> {
     tokio::time::sleep(Duration::from_secs(3)).await;
 
-    state.playlist_generator.update_playlist(&body.playlist_id).await?;
-    state.database.set_current_playlist(&body.playlist_id).await?;
+    state
+        .playlist_generator
+        .update_playlist(&body.playlist_id)
+        .await?;
+    state
+        .database
+        .set_current_playlist(&body.playlist_id)
+        .await?;
 
     let (current_playlist, available_playlists) = get_playlist_info(&state).await?;
     Ok(state
@@ -55,8 +65,20 @@ async fn set_playlist(
         .selected_playlist(current_playlist.as_deref(), available_playlists))
 }
 
+async fn skip_track(State(state): State<AppState>) -> crate::Result<()> {
+    state
+        .liquidsoap
+        .skip_track()
+        .await
+        .into_diagnostic()
+        .with_context(|| "Failed to contact Liquidsoap instance")?;
+
+    Ok(())
+}
+
 pub fn routes() -> Router<AppState> {
     Router::new()
         .route("/", get(admin_page))
         .route("/playlist", post(set_playlist))
+        .route("/skip", post(skip_track))
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,6 +1,9 @@
 use axum::extract::FromRef;
 
-use crate::{apis::ApiClient, database::AppDatabase, playlist::PlaylistGenerator, templates::TemplateRenderer, tracks::TrackCache};
+use crate::{
+    apis::ApiClient, database::AppDatabase, liquidsoap::unix::UnixLiquidsoapBackend,
+    playlist::PlaylistGenerator, templates::TemplateRenderer, tracks::TrackCache,
+};
 
 #[derive(Clone, FromRef)]
 pub struct AppState {
@@ -10,10 +13,19 @@ pub struct AppState {
     pub playlist_generator: PlaylistGenerator,
     pub template_renderer: TemplateRenderer,
     pub track_cache: TrackCache,
+    pub liquidsoap: UnixLiquidsoapBackend,
 }
 
 impl AppState {
-    pub fn new(api_client: ApiClient, api_token: String, database: AppDatabase, playlist_generator: PlaylistGenerator, template_renderer: TemplateRenderer, track_cache: TrackCache) -> Self {
+    pub fn new(
+        api_client: ApiClient,
+        api_token: String,
+        database: AppDatabase,
+        playlist_generator: PlaylistGenerator,
+        template_renderer: TemplateRenderer,
+        track_cache: TrackCache,
+        liquidsoap: UnixLiquidsoapBackend,
+    ) -> Self {
         Self {
             api_client,
             api_token,
@@ -21,6 +33,7 @@ impl AppState {
             playlist_generator,
             template_renderer,
             track_cache,
+            liquidsoap,
         }
     }
 }

--- a/src/templates/player.rs
+++ b/src/templates/player.rs
@@ -12,9 +12,15 @@ impl TemplateRenderer {
 
                 audio #player {}
 
-                .card-body {
+                .card-body style="display: flex; gap: 10px;" {
                     button.btn.btn-outline-primary #toggle-button type="button" {
                         "Play"
+                    }
+
+                    button.btn.btn-primary hx-post="/skip" hx-swap="none" {
+                        span.htmx-indicator.spinner-border.spinner-border-sm aria-hidden="true" {}
+                        (" ")
+                        span { "Skip" }
                     }
                 }
 


### PR DESCRIPTION
This is a **breaking** change. Closes #1.

This pull request adds a skip button to the admin page. Liquidsoap is communicated with using a built-in Unix socket. As the script needs to have a path provided to it, a new environment variable `UNIX_SOCKET_PATH` has been added. Due to this, this PR is breaking.

Other unrelated items in this PR include adding a `justfile` for easier access to development related commands, and adding a parameter to a function call in the Liquidsoap script, which allows it to run on 2.4+. Please check these changes on the deployment version of Liquidsoap.

The reason for all the formatting changes in files is my IDE's auto-`cargo fmt`.